### PR TITLE
Create new guid for test site

### DIFF
--- a/src/QuickBlocks.TestSite/appsettings.json
+++ b/src/QuickBlocks.TestSite/appsettings.json
@@ -13,7 +13,7 @@
   "Umbraco": {
     "CMS": {
       "Global": {
-        "Id": "1bbd3e7b-51ea-450e-99ea-cec52c18a1f9",
+        "Id": "5a24fea3-3170-4cf7-9b92-1ccd4a1e73ab",
         "SanitizeTinyMce": true
       },
       "Content": {


### PR DESCRIPTION
I recently realised that my package starter template doesn't replace the guid in the test site's appSettings.json file (which it should!). I'll get that fixed but here's a PR with a new one for you!