### PR TITLE
added data type mappers collections

### DIFF
--- a/docs/ModifyingDefaultConfiguration.md
+++ b/docs/ModifyingDefaultConfiguration.md
@@ -1,0 +1,52 @@
+# Modifying the default configuration
+
+## Adding DataType mappers
+
+QuickBlocks includes a [collection](https://docs.umbraco.com/umbraco-cms/implementation/composing#collections) of mappers used to link html element to default Umbraco data types.
+
+For example, when the parser finds an `h1` element, it creates a property that uses a `textstring` datatype for it. You can modify this behaviour by modifying the mappers collection.
+
+First we need to create a new mapper. To do so, create a new class that implements `IDataTypeMapper`.
+
+```csharp
+public class TextareaDataTypeMapper : IDataTypeMapper
+{
+    public IEnumerable<string> HtmlElements => new[] {"h1"} ;
+
+    public string DataTypeName => "textarea";
+}
+```
+
+Next, we need to add our mapper to the QuickBlocks collection. Y For this to work you will need to create a [composer](https://docs.umbraco.com/umbraco-cms/implementation/composing).
+
+Then add the type mapper using the `QuickBlockDataTypeMappers` extension.
+
+> ℹ️ Note that QuickBlocks come with a `HeadersDataTypeMapper` that maps `h1` to a `textstring` datatype. In order for the new mapper to be able to override the default configuration, we need to append it to the collection after `HeadersDataTypeMapper` using `InsertAfter`
+
+
+```csharp
+
+internal class MyDataTypeMappersComposer : IComposer
+{
+    public void Compose(IUmbracoBuilder builder)
+    {        
+
+        builder.QuickBlockDataTypeMappers()
+                    .InsertAfter<HeadersDataTypeMapper, TextareaDataTypeMapper>();               
+    }
+}
+
+```
+
+## Changing the default data type mapper
+If a mapper is not found for a given html element, QuickBlocks will create a property using a `textstring` data type.
+
+This datatype can be modify. To do this, you need to go to your `Startup.cs` file and in the `ConfigureServices` method, you can configure the default options.
+
+```csharp   
+services.Configure<QuickBlocksDefaultOptions>(cfg =>
+{
+    cfg.DefaultDataTypeName = "Textarea";
+});
+```
+

--- a/src/QuickBlocks.TestSite/Startup.cs
+++ b/src/QuickBlocks.TestSite/Startup.cs
@@ -1,3 +1,5 @@
+using Umbraco.Community.QuickBlocks;
+
 namespace QuickBlocks.TestSite
 {
     public class Startup
@@ -34,6 +36,12 @@ namespace QuickBlocks.TestSite
                 .AddWebsite()
                 .AddComposers()
                 .Build();
+
+            // Example: hot to modify the default data type name
+            //services.Configure<QuickBlocksDefaultOptions>(cfg =>
+            //{
+            //    cfg.DefaultDataTypeName = "Textarea";
+            //});
         }
 
         /// <summary>

--- a/src/QuickBlocks.TestSite/TextareaDataTypeMapper.cs
+++ b/src/QuickBlocks.TestSite/TextareaDataTypeMapper.cs
@@ -1,0 +1,11 @@
+using Umbraco.Community.QuickBlocks.Models;
+
+namespace QuickBlocks.TestSite
+{
+    public class TextareaDataTypeMapper : IDataTypeMapper
+    {
+        public IEnumerable<string> HtmlElements => new[] {"h1"} ;
+
+        public string DataTypeName => "textarea";
+    }
+}

--- a/src/QuickBlocks.TestSite/TextareaMapperComposer.cs
+++ b/src/QuickBlocks.TestSite/TextareaMapperComposer.cs
@@ -1,0 +1,18 @@
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Community.QuickBlocks;
+
+namespace QuickBlocks.TestSite
+{
+    // Use to test the ability to add a new data type mapper to the datatype mappers collection
+    [ComposeAfter(typeof(QuickBlocksComposer))]
+    internal class TextAreaMapperComposer : IComposer
+    {
+        public void Compose(IUmbracoBuilder builder)
+        {
+            // Example: how to add a new data type mapper to the datatype mappers collection
+            //builder.QuickBlockDataTypeMappers()
+            //            .InsertAfter<HeadersDataTypeMapper, TextareaDataTypeMapper>();
+
+        }
+    }
+}

--- a/src/QuickBlocks/Composing/RegisterServicesComposer.cs
+++ b/src/QuickBlocks/Composing/RegisterServicesComposer.cs
@@ -2,6 +2,7 @@
 using Umbraco.Community.QuickBlocks.Services;
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Community.QuickBlocks.Services.Resolvers;
 
 namespace Umbraco.Community.QuickBlocks.Composing;
 
@@ -11,5 +12,6 @@ public class RegisterServicesComposer : IComposer
     {
         builder.Services.AddTransient<IBlockCreationService, BlockCreationService>();
         builder.Services.AddTransient<IBlockParsingService, BlockParsingService>();
+        builder.Services.AddTransient<IDataTypeNameResolver, DataTypeNameResolver>();
     }
 }

--- a/src/QuickBlocks/DataTypeMappersCollection.cs
+++ b/src/QuickBlocks/DataTypeMappersCollection.cs
@@ -1,0 +1,27 @@
+﻿using Umbraco.Cms.Core.Composing;
+using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Community.QuickBlocks.Models;
+
+namespace Umbraco.Community.QuickBlocks;
+
+
+
+public class DataTypeMappersCollection : BuilderCollectionBase<IDataTypeMapper>
+{
+    public DataTypeMappersCollection(Func<IEnumerable<IDataTypeMapper>> items) : base(items)
+    {
+    }
+}
+
+public class DataTypeMappersCollectionBuilder : OrderedCollectionBuilderBase<DataTypeMappersCollectionBuilder, DataTypeMappersCollection, IDataTypeMapper>
+{
+    protected override DataTypeMappersCollectionBuilder This => this;
+}
+
+public static class WebCompositionExtensions
+{
+    public static DataTypeMappersCollectionBuilder QuickBlockDataTypeMappers(this IUmbracoBuilder builder)
+        => builder.WithCollectionBuilder<DataTypeMappersCollectionBuilder>();
+
+
+}

--- a/src/QuickBlocks/Models/DataTypeMappers/DataTypeMappers.cs
+++ b/src/QuickBlocks/Models/DataTypeMappers/DataTypeMappers.cs
@@ -1,0 +1,27 @@
+﻿namespace Umbraco.Community.QuickBlocks.Models.DataTypeMappers;
+
+
+public class ImgDataTypeMapper : IDataTypeMapper
+{
+    public IEnumerable<string> HtmlElements => new[] { "img" };
+    public string DataTypeName => "Image Media Picker";
+}
+
+public class HeadersDataTypeMapper : IDataTypeMapper
+{
+    public IEnumerable<string> HtmlElements => new[] { "h1", "h2", "h3", "h4", "h5", "h6" };
+    public string DataTypeName => "Textstring";
+}
+
+public class ParagraphDataTypeMapper : IDataTypeMapper
+{
+    public IEnumerable<string> HtmlElements => new[] { "p" };
+    public string DataTypeName => "Richtext editor";
+}
+
+public class AnchorDataTypeMapper : IDataTypeMapper
+{
+    public IEnumerable<string> HtmlElements => new[] { "a" };
+    public string DataTypeName => "Single Url Picker";
+}
+

--- a/src/QuickBlocks/Models/IDataTypeMapper.cs
+++ b/src/QuickBlocks/Models/IDataTypeMapper.cs
@@ -1,0 +1,7 @@
+﻿namespace Umbraco.Community.QuickBlocks.Models;
+
+public interface IDataTypeMapper
+{
+    IEnumerable<string> HtmlElements { get; }
+    string DataTypeName { get; }
+}

--- a/src/QuickBlocks/QuickBlocks.csproj
+++ b/src/QuickBlocks/QuickBlocks.csproj
@@ -23,6 +23,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Umbraco.Cms.Core" Version="10.4.0" />
     <PackageReference Include="Umbraco.Cms.Web.Website" Version="10.4.0" />
     <PackageReference Include="Umbraco.Cms.Web.BackOffice" Version="10.4.0" />
   </ItemGroup>

--- a/src/QuickBlocks/QuickBlocksComposer.cs
+++ b/src/QuickBlocks/QuickBlocksComposer.cs
@@ -1,12 +1,20 @@
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.DependencyInjection;
+using Umbraco.Community.QuickBlocks.Models.DataTypeMappers;
 
 namespace Umbraco.Community.QuickBlocks;
 
-internal class QuickBlocksComposer : IComposer
+public class QuickBlocksComposer : IComposer
 {
     public void Compose(IUmbracoBuilder builder)
     {
         builder.ManifestFilters().Append<QuickBlocksManifestFilter>();
+
+        builder.QuickBlockDataTypeMappers()
+                    .Append<ImgDataTypeMapper>()
+                    .Append<HeadersDataTypeMapper>()
+                    .Append<ParagraphDataTypeMapper>()
+                    .Append<AnchorDataTypeMapper>();
     }
 }
+

--- a/src/QuickBlocks/QuickBlocksDefaultOptions.cs
+++ b/src/QuickBlocks/QuickBlocksDefaultOptions.cs
@@ -1,0 +1,5 @@
+﻿namespace Umbraco.Community.QuickBlocks;
+public class QuickBlocksDefaultOptions
+{
+    public string DefaultDataTypeName { get; set; } = "Textstring";
+}

--- a/src/QuickBlocks/Services/BlockParsingService.cs
+++ b/src/QuickBlocks/Services/BlockParsingService.cs
@@ -2,16 +2,19 @@
 
 using Umbraco.Cms.Core.Strings;
 using Umbraco.Community.QuickBlocks.Models;
+using Umbraco.Community.QuickBlocks.Services.Resolvers;
 
 namespace Umbraco.Community.QuickBlocks.Services;
 
 public class BlockParsingService : IBlockParsingService
 {
     private readonly IShortStringHelper _shortStringHelper;
+    private readonly IDataTypeNameResolver _dataTypeNameResolver;
 
-    public BlockParsingService(IShortStringHelper shortStringHelper)
+    public BlockParsingService(IShortStringHelper shortStringHelper, IDataTypeNameResolver dataTypeNameResolver)
     {
         _shortStringHelper = shortStringHelper;
+        _dataTypeNameResolver = dataTypeNameResolver;
     }
 
     public List<BlockListModel> GetLists(string html, bool isNestedList, string prefix = "[BlockList]")
@@ -188,29 +191,7 @@ public class BlockParsingService : IBlockParsingService
 
             if (!string.IsNullOrWhiteSpace(itemName) && string.IsNullOrWhiteSpace(itemType))
             {
-                switch (propertyNode.OriginalName.ToLower())
-                {
-                    case "img":
-                        itemType = "Image Media Picker";
-                        break;
-                    case "h1":
-                    case "h2":
-                    case "h3":
-                    case "h4":
-                    case "h5":
-                    case "h6":
-                        itemType = "Textstring";
-                        break;
-                    case "p":
-                        itemType = "Richtext editor";
-                        break;
-                    case "a":
-                        itemType = "Single Url Picker";
-                        break;
-                    default:
-                        itemType = "Textstring";
-                        break;
-                }
+                itemType = _dataTypeNameResolver.GetDataTypeName(propertyNode.OriginalName.ToLower());
             }
 
             if (!string.IsNullOrWhiteSpace(itemName))

--- a/src/QuickBlocks/Services/Resolvers/DataTypeNameResolver.cs
+++ b/src/QuickBlocks/Services/Resolvers/DataTypeNameResolver.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.Extensions.Options;
+
+namespace Umbraco.Community.QuickBlocks.Services.Resolvers;
+public class DataTypeNameResolver : IDataTypeNameResolver
+{
+    private readonly DataTypeMappersCollection _dataTypeMappers;
+    private readonly IOptions<QuickBlocksDefaultOptions> _defaultOptions;
+
+    public DataTypeNameResolver(DataTypeMappersCollection dataTypeMappers, IOptions<QuickBlocksDefaultOptions> defaultOptions)
+    {
+        _dataTypeMappers = dataTypeMappers;
+        _defaultOptions = defaultOptions;
+    }
+
+    public string GetDataTypeName(string htmlElement)
+    {
+
+        var dt = _dataTypeMappers.LastOrDefault(dt=>dt.HtmlElements.Contains(htmlElement));
+        
+        return dt?.DataTypeName ?? _defaultOptions.Value.DefaultDataTypeName;
+                
+    }
+}

--- a/src/QuickBlocks/Services/Resolvers/IDataTypeNameResolver.cs
+++ b/src/QuickBlocks/Services/Resolvers/IDataTypeNameResolver.cs
@@ -1,0 +1,6 @@
+﻿namespace Umbraco.Community.QuickBlocks.Services.Resolvers;
+
+public interface IDataTypeNameResolver
+{
+    string GetDataTypeName(string htmlElement);
+}


### PR DESCRIPTION
I have added a collection to be able to add or modify the data type mappers. I have reconfigured the datatypes using this approach in a composer. 

Let me know if you need some explanation. I think this feature makes the package more flexible. Let me know your thoughts 😃 

I have also added some documentation so hopefully makes things clear.