### PR TITLE
Prevent Exception when block has no properties defined

### DIFF
--- a/src/QuickBlocks/Services/BlockCreationService.cs
+++ b/src/QuickBlocks/Services/BlockCreationService.cs
@@ -108,6 +108,8 @@ public class BlockCreationService : IBlockCreationService
 
     public void RenderProperties(HtmlNodeCollection properties, string context)
     {
+        if (properties == null) return;
+
         foreach (var item in properties)
         {
             var name = item.Attributes["data-prop-name"].Value;

--- a/src/QuickBlocks/Services/BlockParsingService.cs
+++ b/src/QuickBlocks/Services/BlockParsingService.cs
@@ -182,7 +182,7 @@ public class BlockParsingService : IBlockParsingService
         var propertyNodes = doc.DocumentNode.SelectNodes("//*[@data-prop-name][not(ancestor::*[@data-list-name]) and not(ancestor::*[@data-sub-list-name])]");
 
         var descendants = doc.DocumentNode.Descendants();
-        if (descendants == null || !descendants.Any()) return properties;
+        if (propertyNodes == null || descendants == null || !descendants.Any()) return properties;
 
         foreach (var propertyNode in propertyNodes)
         {            


### PR DESCRIPTION
First 'baby-steps' contrib to this repo.
The change in the Block CreationService.cs is flagged by intellisense saying that properties is not null here, but I can assure you iit can be as the rest of the code stands.