### PR TITLE
Add umbraco-block-builder Claude skill and MCP configuration

### DIFF
--- a/.claude/skills/umbraco-block-builder/SKILL.md
+++ b/.claude/skills/umbraco-block-builder/SKILL.md
@@ -7,9 +7,18 @@ description: >
   the Umbraco Developer MCP Server. Use when the developer wants to set up Umbraco
   block lists, create content types from an HTML file, scaffold a block-based page
   structure, or convert a prototype to Umbraco content types. Triggered by phrases
-  like "build the blocks", "scaffold this page", "create content types", or
-  "set up Umbraco from this HTML".
+  like "build the blocks", "scaffold this page", "create content types from this HTML",
+  "set up Umbraco blocks", or "convert this prototype to Umbraco". Do NOT use for
+  general Umbraco content editing, querying existing content, or non-block templates.
 user_invocable: true
+compatibility: >
+  Requires Umbraco 17+ with the Management API enabled. Requires the umbraco-mcp MCP
+  server connected (npx @umbraco-cms/mcp-dev@17). An Umbraco API User with admin
+  permissions must be configured. Use against a development or staging instance only.
+metadata:
+  mcp-server: umbraco-mcp
+  version: 1.0.0
+  author: QuickBlocks
 ---
 
 # Umbraco Block Builder
@@ -24,7 +33,7 @@ the MCP tools as your only write mechanism.
 
 ---
 
-## Ground Rules
+## Critical Rules
 
 These are non-negotiable. Do not proceed if any cannot be satisfied.
 
@@ -398,78 +407,10 @@ If any item shows an error, explain what failed and offer to retry or skip.
 
 ---
 
-## Worked Example
+## Reference: Worked Example
 
-**Input (unannotated HTML):**
+See `references/worked-example.md` for a complete end-to-end walkthrough:
+input HTML → proposed structure → full MCP call sequence → all generated Razor files.
 
-```html
-<main>
-  <section class="hero">
-    <h1>Welcome to Acme</h1>
-    <p>We build things that matter.</p>
-    <img src="hero.jpg" alt="Hero image">
-    <a href="/about">Learn More</a>
-  </section>
-
-  <section class="services">
-    <h2>Our Services</h2>
-    <div class="service-grid">
-      <div class="service-card">
-        <img src="icon.svg" alt="icon">
-        <h4>Service Name</h4>
-        <p>Service description here.</p>
-      </div>
-    </div>
-  </section>
-</main>
-```
-
-**Proposed structure (shown to developer before any writes):**
-
-```
-## Proposed Block Architecture
-
-**Page type:** Home Page (alias: homePage)
-
-**Block list:** Main Content
-  ├── Hero (element: heroRow)
-  │     title: Textstring
-  │     bodyText: Rich Text Editor
-  │     image: Image Media Picker
-  │     link: Single URL Picker
-  │   settings: heroSettings (hide: True/False)
-  │
-  └── Services (element: servicesRow)
-        title: Textstring
-        [nested list] Service Grid
-            Service Card (element: serviceCardItem)
-                icon: Image Media Picker
-                title: Textstring
-                description: Rich Text Editor
-      settings: none
-
-Does this look right? Reply YES to proceed, or tell me what to change.
-```
-
-**Generated `Views/Partials/blocklist/Components/heroRow.cshtml`:**
-
-```razor
-@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<Umbraco.Cms.Core.Models.Blocks.BlockListItem>
-
-@{
-    var row      = (HeroRow)Model.Content;
-    var settings = (HeroSettings)Model.Settings;
-
-    if (settings.Hide) { return; }
-}
-
-<section class="hero">
-    <h1>@row.Title</h1>
-    @Html.Raw(row.BodyText)
-    <img src="@Url.GetCropUrl(row.Image, 1920, 600)" alt="@row.Image?.Name" />
-    @if (row.Link != null)
-    {
-        <a href="@row.Link.Url" target="@row.Link.Target">@row.Link.Name</a>
-    }
-</section>
-```
+Consult it whenever you need to calibrate naming conventions, MCP call order, or
+the exact shape of a generated partial view.

--- a/.claude/skills/umbraco-block-builder/SKILL.md
+++ b/.claude/skills/umbraco-block-builder/SKILL.md
@@ -1,0 +1,475 @@
+---
+name: umbraco-block-builder
+description: >
+  Scaffolds a complete Umbraco 17 block list architecture from an HTML prototype,
+  natural language description, or screenshot. Creates element types, settings types,
+  block list data types, partial views, page content types, and Razor templates via
+  the Umbraco Developer MCP Server. Use when the developer wants to set up Umbraco
+  block lists, create content types from an HTML file, scaffold a block-based page
+  structure, or convert a prototype to Umbraco content types. Triggered by phrases
+  like "build the blocks", "scaffold this page", "create content types", or
+  "set up Umbraco from this HTML".
+user_invocable: true
+---
+
+# Umbraco Block Builder
+
+You are scaffolding a complete Umbraco 17 block list architecture from a developer-provided
+input. You have access to the **Umbraco Developer MCP Server** via the `umbraco-mcp` MCP
+connection.
+
+Your job is to turn design intent (HTML, description, or screenshot) into a set of real
+Umbraco artefacts — document types, data types, templates, and Razor partial views — using
+the MCP tools as your only write mechanism.
+
+---
+
+## Ground Rules
+
+These are non-negotiable. Do not proceed if any cannot be satisfied.
+
+1. **Confirm before writing.** Never call a write MCP tool (`create-*`, `update-*`) without
+   first presenting the proposed structure to the developer and receiving explicit confirmation.
+   A mistake creates real artefacts in a live CMS that are harder to remove than to prevent.
+
+2. **Check before creating.** Always call `get-all-document-types` and `get-all-data-types`
+   before creating anything. If a matching artefact already exists, use its GUID — do not
+   create a duplicate.
+
+3. **Enforce creation order.** The block list data type JSON requires the GUIDs of element
+   types that must already exist. Never attempt to create a block list data type before all
+   referenced element types are confirmed as created. The exact dependency order is in Step 5.
+
+4. **Never guess GUIDs.** Resolve all GUIDs by calling `get-all-data-types` or
+   `get-all-document-types`. A wrong GUID silently breaks the block list.
+
+5. **Umbraco 17 configuration format.** The block list `configuration` field uses an array
+   of `{ alias, value }` pairs — NOT a flat object. See the schema in Step 6.
+
+6. **Partial view path.** Block component partials go at:
+   `Views/Partials/blocklist/Components/{alias}.cshtml`
+   If the Umbraco subfolder bug (#16823) causes a 404, fall back to root partials and note
+   the workaround in the summary.
+
+7. **Use a non-production environment.** Remind the developer that scaffolding should be
+   done against a development or staging instance, not production.
+
+---
+
+## Step 1 — Understand the Input
+
+Accept any of the following — no `data-*` annotation is required:
+
+- **Plain HTML** — a prototype or partial page
+- **Natural language** — "I need a hero, a 3-column grid, and a testimonials carousel"
+- **Screenshot or Figma image** — describe the visual structure, then treat as natural language
+- **Mixed input** — HTML plus verbal additions
+
+From the input, identify:
+
+| What to find | What it becomes |
+|---|---|
+| The page name | Page document type (e.g. `homePage`) |
+| Each distinct content section | A block type (element type) |
+| Properties per block | Inferred from HTML element types (see Step 2) |
+| Repeated sibling groups | Nested block list |
+| Any block needing show/hide control | Settings type with `hide: True/False` |
+
+**Naming rules:**
+- Convert to PascalCase for type aliases (e.g. `heroRow`, `heroSettings`)
+- Use sentence-case display names (e.g. `"Hero"`, `"Hero Settings"`)
+- Derive names from CSS class names, element IDs, and heading text when present
+- `<section class="hero">` → block called `Hero` (alias: `heroRow`)
+- `<div class="service-card">` repeated → nested block called `Service Card` (alias: `serviceCardItem`)
+
+If the input is ambiguous, ask the developer one focused clarifying question before proceeding
+to the proposed structure. Do not ask multiple questions at once.
+
+---
+
+## Step 2 — Infer Data Types
+
+Map HTML elements to Umbraco data types using this table:
+
+| HTML element or context | Umbraco data type | Razor rendering |
+|---|---|---|
+| `<img>` | Image Media Picker | `@Url.GetCropUrl(row.Prop, w, h)` |
+| `<h1>`–`<h6>` | Textstring | `@row.Prop` |
+| `<p>` (body copy) | Rich Text Editor | `@Html.Raw(row.Prop)` |
+| `<a>` (single link) | Single URL Picker | `@row.Prop?.Url` / `.Name` / `.Target` |
+| `<a>` (repeated in list) | Multi URL Picker | loop with `@item.Url` |
+| `<video>` | Media Picker | `@row.Prop?.Url` |
+| `<input type="text">` | Textstring | `@row.Prop` |
+| `<textarea>` | Textarea | `@row.Prop` |
+| `<select>` | Dropdown | `@row.Prop` |
+| `<input type="checkbox">` | True/False | `@if (row.Prop) { ... }` |
+| Repeated sibling group | Nested block list | `@Html.GetBlockListHtml(row.Prop)` |
+| Anything else | Textstring (default) | `@row.Prop` |
+
+Use `get-all-data-types` to resolve the exact GUID and confirmed name for every data type
+before building the block list configuration JSON. Never assume names or GUIDs.
+
+---
+
+## Step 3 — Present the Proposed Structure
+
+Before making any write calls, output a structured summary in this exact format:
+
+```
+## Proposed Block Architecture
+
+**Page type:** {Display Name} (alias: {camelCaseAlias})
+
+**Block list:** {Block List Name}
+  ├── {Block Name} (element: {alias})
+  │     {property}: {Data Type}
+  │     {property}: {Data Type}
+  │   settings: {settingsAlias} (hide: True/False)
+  │
+  └── {Block Name} (element: {alias})
+        {property}: {Data Type}
+        [nested list] {Nested List Name}
+            {Item Name} (element: {itemAlias})
+                {property}: {Data Type}
+      settings: none
+
+Does this look right? Reply YES to proceed, or tell me what to change.
+```
+
+**Wait for explicit confirmation before proceeding.** If the developer replies with changes,
+update the model and re-present the summary. Only proceed when the developer says YES (or
+equivalent).
+
+---
+
+## Step 4 — Resolve Existing State
+
+Before creating anything, call:
+
+```
+get-all-document-types   → build a map of alias → id (to avoid duplicates and reuse GUIDs)
+get-all-data-types       → build a map of name → id (to resolve GUIDs for Image Media Picker etc.)
+get-server-information   → confirm Umbraco version is 17+
+```
+
+Flag to the developer if the Umbraco version is not 17 — the configuration schema differs.
+
+---
+
+## Step 5 — Create in Dependency Order
+
+Execute in this exact order. Each step depends on all previous steps completing successfully.
+
+```
+ 1. create-document-type-folder  → "Elements"
+ 2. create-document-type-folder  → "Elements/Content Models"
+ 3. create-document-type-folder  → "Elements/Settings Models"
+ 4. create-document-type-folder  → "Pages"
+ 5. get-all-data-types           → resolve GUIDs for all needed primitive data types
+ 6. create-element-type          → one per block content type (e.g. heroRow)
+ 7. create-element-type          → one per block settings type (e.g. heroSettings)
+                                   Always include a "Hide" property of type True/False
+ 8. create-data-type             → one per nested block list (if any)
+                                   Uses GUIDs from steps 6–7
+ 9. create-data-type             → page-level block list(s)
+                                   Uses GUIDs from steps 6–7
+10. create-document-type         → the page content type
+                                   References block list data types from step 9
+11. create-template              → master.cshtml (see Step 7a)
+12. create-template              → {pageAlias}.cshtml with masterTemplateAlias: "master" (see Step 7b)
+13. create-partial-view          → Views/Partials/navigation.cshtml (see Step 7c)
+14. create-partial-view          → Views/Partials/footer.cshtml (see Step 7c)
+15. create-partial-view          → Views/Partials/blocklist/default.cshtml (see Step 7d)
+16. create-partial-view          → Views/Partials/blocklist/Components/{alias}.cshtml per block (see Step 7e)
+17. get-document-type / get-data-type → verify all created artefacts (see Step 8)
+```
+
+If any step returns a conflict (artefact already exists), use the existing item's GUID and
+continue. Do not abort.
+
+---
+
+## Step 6 — Block List Data Type JSON (Umbraco 17)
+
+Use this exact `configuration` structure when calling `create-data-type`:
+
+```json
+{
+  "name": "{Block List Display Name}",
+  "editorAlias": "Umbraco.BlockList",
+  "editorUiAlias": "Umb.PropertyEditorUi.BlockList",
+  "configuration": [
+    {
+      "alias": "blocks",
+      "value": [
+        {
+          "contentElementTypeKey": "<GUID of content element type>",
+          "settingsElementTypeKey": "<GUID of settings element type, or null if none>",
+          "label": "{{ !title || title == '' ? '{Block Display Name}' : title }}",
+          "editorSize": "medium",
+          "forceHideContentEditorInOverlay": false,
+          "iconColor": "#1b264f",
+          "backgroundColor": "#ffffff"
+        }
+      ]
+    },
+    { "alias": "validationLimit",          "value": { "min": null, "max": null } },
+    { "alias": "useSingleBlockMode",       "value": false },
+    { "alias": "useLiveEditing",           "value": false },
+    { "alias": "useInlineEditingAsDefault","value": false },
+    { "alias": "maxPropertyWidth",         "value": "100%" }
+  ]
+}
+```
+
+**Critical:** Both `editorAlias` and `editorUiAlias` are required in Umbraco 17. Omitting
+either will cause the data type to be created but non-functional in the editor.
+
+For block lists with multiple block types, add one object per block type in the `blocks` array.
+
+---
+
+## Step 7a — Master Template
+
+The master template is the full HTML shell (nav + layout + footer). Transform the input HTML:
+
+1. Replace the main content element with `@RenderBody()`
+2. Replace nav/footer elements with `@await Html.PartialAsync("~/Views/Partials/{name}.cshtml")`
+3. Strip all `data-*` attributes
+
+```razor
+@* master.cshtml — no @inherits, no Layout *@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <title>{Site Name}</title>
+</head>
+<body>
+    @await Html.PartialAsync("~/Views/Partials/navigation.cshtml")
+
+    @RenderBody()
+
+    @await Html.PartialAsync("~/Views/Partials/footer.cshtml")
+</body>
+</html>
+```
+
+MCP call: `create-template` with `name: "Master"`, `alias: "master"`, content as above.
+
+---
+
+## Step 7b — Content Page Template
+
+The content page template contains only the main content region. It sets `Layout = "master.cshtml"`
+and calls `@Html.GetBlockListHtml()` for each block list property on the page:
+
+```razor
+@using Umbraco.Cms.Web.Common.PublishedModels;
+@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<ContentModels.{PagePascalAlias}>
+    @using ContentModels = Umbraco.Cms.Web.Common.PublishedModels;
+@{
+    Layout = "master.cshtml";
+}
+
+<main>
+    @Html.GetBlockListHtml(Model.{BlockListPropertyAlias})
+</main>
+```
+
+MCP call: `create-template` with `name: "{Page Name}"`, `alias: "{pageAlias}"`,
+`masterTemplateAlias: "master"`, content as above.
+
+---
+
+## Step 7c — Structural Partials (Nav, Footer, etc.)
+
+For each element that belongs in a reusable partial (navigation, footer, cookie banner):
+
+```razor
+@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage
+
+{original HTML with data-* attributes stripped}
+```
+
+MCP call: `create-partial-view` at `Views/Partials/{name}.cshtml`.
+
+---
+
+## Step 7d — Block List Dispatcher (Fixed File)
+
+This file is always identical. It routes every block to its component partial by convention.
+Create it once; it never needs to change as new block types are added.
+
+```razor
+@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<Umbraco.Cms.Core.Models.Blocks.BlockListModel>
+@{
+    if (Model?.Any() != true) { return; }
+}
+<div class="umb-block-list">
+    @foreach (var block in Model)
+    {
+        if (block?.ContentUdi == null) { continue; }
+        var data = block.Content;
+
+        @await Html.PartialAsync("blocklist/Components/" + data.ContentType.Alias, block)
+    }
+</div>
+```
+
+MCP call: `create-partial-view` at `Views/Partials/blocklist/default.cshtml`.
+
+---
+
+## Step 7e — Block Component Partials
+
+One file per block type. Each casts `BlockListItem` to the block's typed content and settings
+models, checks `settings.Hide`, and renders the HTML with Razor expressions:
+
+```razor
+@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<Umbraco.Cms.Core.Models.Blocks.BlockListItem>
+
+@{
+    var row      = ({ContentTypePascalAlias})Model.Content;
+    var settings = ({SettingsTypePascalAlias})Model.Settings;
+
+    if (settings.Hide) { return; }
+}
+
+{HTML from original prototype, with property values replaced by Razor expressions}
+```
+
+**Property rendering reference:**
+
+| Data type | Razor expression |
+|---|---|
+| Textstring | `@row.{PropAlias}` |
+| Rich Text Editor | `@Html.Raw(row.{PropAlias})` |
+| Image Media Picker | `<img src="@Url.GetCropUrl(row.{PropAlias}, 800, 600)" alt="@row.{PropAlias}?.Name" />` |
+| Single URL Picker | `<a href="@row.{PropAlias}?.Url" target="@row.{PropAlias}?.Target">@row.{PropAlias}?.Name</a>` |
+| True/False | `@if (row.{PropAlias}) { ... }` |
+| Nested block list | `@Html.GetBlockListHtml(row.{PropAlias})` |
+
+MCP call: `create-partial-view` at `Views/Partials/blocklist/Components/{alias}.cshtml`.
+
+---
+
+## Step 8 — Verify and Report
+
+After all creation steps complete, verify the key artefacts:
+
+```
+get-document-type  → for each created document/element type
+get-data-type      → for each created block list data type
+```
+
+Then output a summary table:
+
+```
+## Build Complete
+
+| Artefact | Name | Status |
+|---|---|---|
+| Element type | heroRow | ✓ Created |
+| Element type | heroSettings | ✓ Created |
+| Block list data type | Main Content | ✓ Created |
+| Page document type | homePage | ✓ Created |
+| Template | master.cshtml | ✓ Created |
+| Template | homePage.cshtml | ✓ Created |
+| Structural partial | navigation.cshtml | ✓ Created |
+| Structural partial | footer.cshtml | ✓ Created |
+| Block list dispatcher | blocklist/default.cshtml | ✓ Created |
+| Component partial | blocklist/Components/heroRow.cshtml | ✓ Created |
+```
+
+If any item shows an error, explain what failed and offer to retry or skip.
+
+---
+
+## Error Handling
+
+| Error condition | Action |
+|---|---|
+| `create-element-type` conflict (already exists) | Use existing GUID and continue |
+| `create-partial-view` 404 on deep path (Umbraco bug #16823) | Create at root partials folder, note workaround in summary |
+| GUID lookup fails | Call `get-data-type-search` with type name as fallback |
+| `get-server-information` shows Umbraco < 17 | Warn developer — block list JSON schema differs; do not proceed without confirmation |
+| MCP connection unavailable | Stop and ask developer to check `.mcp.json` and `UMBRACO_BASE_URL` |
+
+---
+
+## Worked Example
+
+**Input (unannotated HTML):**
+
+```html
+<main>
+  <section class="hero">
+    <h1>Welcome to Acme</h1>
+    <p>We build things that matter.</p>
+    <img src="hero.jpg" alt="Hero image">
+    <a href="/about">Learn More</a>
+  </section>
+
+  <section class="services">
+    <h2>Our Services</h2>
+    <div class="service-grid">
+      <div class="service-card">
+        <img src="icon.svg" alt="icon">
+        <h4>Service Name</h4>
+        <p>Service description here.</p>
+      </div>
+    </div>
+  </section>
+</main>
+```
+
+**Proposed structure (shown to developer before any writes):**
+
+```
+## Proposed Block Architecture
+
+**Page type:** Home Page (alias: homePage)
+
+**Block list:** Main Content
+  ├── Hero (element: heroRow)
+  │     title: Textstring
+  │     bodyText: Rich Text Editor
+  │     image: Image Media Picker
+  │     link: Single URL Picker
+  │   settings: heroSettings (hide: True/False)
+  │
+  └── Services (element: servicesRow)
+        title: Textstring
+        [nested list] Service Grid
+            Service Card (element: serviceCardItem)
+                icon: Image Media Picker
+                title: Textstring
+                description: Rich Text Editor
+      settings: none
+
+Does this look right? Reply YES to proceed, or tell me what to change.
+```
+
+**Generated `Views/Partials/blocklist/Components/heroRow.cshtml`:**
+
+```razor
+@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<Umbraco.Cms.Core.Models.Blocks.BlockListItem>
+
+@{
+    var row      = (HeroRow)Model.Content;
+    var settings = (HeroSettings)Model.Settings;
+
+    if (settings.Hide) { return; }
+}
+
+<section class="hero">
+    <h1>@row.Title</h1>
+    @Html.Raw(row.BodyText)
+    <img src="@Url.GetCropUrl(row.Image, 1920, 600)" alt="@row.Image?.Name" />
+    @if (row.Link != null)
+    {
+        <a href="@row.Link.Url" target="@row.Link.Target">@row.Link.Name</a>
+    }
+</section>
+```

--- a/.claude/skills/umbraco-block-builder/references/worked-example.md
+++ b/.claude/skills/umbraco-block-builder/references/worked-example.md
@@ -1,0 +1,277 @@
+# Worked Example: Hero + Services Page
+
+A complete end-to-end example showing input → proposed structure → MCP call sequence → generated Razor files.
+
+---
+
+## Input (unannotated HTML)
+
+```html
+<body>
+  <nav class="main-nav">
+    <a href="/">Home</a>
+    <a href="/about">About</a>
+  </nav>
+
+  <main>
+    <section class="hero">
+      <h1>Welcome to Acme</h1>
+      <p>We build things that matter.</p>
+      <img src="hero.jpg" alt="Hero image">
+      <a href="/about">Learn More</a>
+    </section>
+
+    <section class="services">
+      <h2>Our Services</h2>
+      <div class="service-grid">
+        <div class="service-card">
+          <img src="icon.svg" alt="icon">
+          <h4>Service Name</h4>
+          <p>Service description here.</p>
+        </div>
+        <div class="service-card">...</div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <p>&copy; 2025 Acme</p>
+  </footer>
+</body>
+```
+
+---
+
+## Proposed Structure (shown to developer before any writes)
+
+```
+## Proposed Block Architecture
+
+**Page type:** Home Page (alias: homePage)
+
+**Block list:** Main Content
+  ├── Hero (element: heroRow)
+  │     title: Textstring
+  │     bodyText: Rich Text Editor
+  │     image: Image Media Picker
+  │     link: Single URL Picker
+  │   settings: heroSettings (hide: True/False)
+  │
+  └── Services (element: servicesRow)
+        title: Textstring
+        [nested list] Service Grid
+            Service Card (element: serviceCardItem)
+                icon: Image Media Picker
+                title: Textstring
+                description: Rich Text Editor
+      settings: none
+
+Does this look right? Reply YES to proceed, or tell me what to change.
+```
+
+---
+
+## MCP Call Sequence (after developer says YES)
+
+```
+ 1.  create-document-type-folder  → "Elements"
+ 2.  create-document-type-folder  → "Elements/Content Models"
+ 3.  create-document-type-folder  → "Elements/Settings Models"
+ 4.  create-document-type-folder  → "Pages"
+ 5.  get-all-data-types           → resolve GUIDs for Textstring, Rich Text Editor,
+                                     Image Media Picker, Single URL Picker, True/False
+ 6.  create-element-type          → heroRow
+ 7.  create-element-type          → heroSettings (with hide: True/False)
+ 8.  create-element-type          → servicesRow
+ 9.  create-element-type          → serviceCardItem
+10.  create-data-type             → "Service Grid" (nested block list, references serviceCardItem)
+11.  create-data-type             → "Main Content" (references heroRow + servicesRow)
+12.  create-document-type         → homePage (with mainContent block list property)
+
+     ── Template generation ──────────────────────────────────────────────────
+
+13.  create-template              → master.cshtml
+14.  create-template              → homePage.cshtml (masterTemplateAlias: "master")
+
+     ── Structural partials ──────────────────────────────────────────────────
+
+15.  create-partial-view          → Views/Partials/navigation.cshtml
+16.  create-partial-view          → Views/Partials/footer.cshtml
+
+     ── Block list wiring ────────────────────────────────────────────────────
+
+17.  create-partial-view          → Views/Partials/blocklist/default.cshtml
+
+     ── Block component partials ─────────────────────────────────────────────
+
+18.  create-partial-view          → Views/Partials/blocklist/Components/heroRow.cshtml
+19.  create-partial-view          → Views/Partials/blocklist/Components/servicesRow.cshtml
+20.  create-partial-view          → Views/Partials/blocklist/Components/serviceCardItem.cshtml
+
+     ── Verification ─────────────────────────────────────────────────────────
+
+21.  get-document-type            → verify heroRow ✓
+22.  get-document-type            → verify servicesRow ✓
+23.  get-data-type                → verify "Main Content" ✓
+```
+
+---
+
+## Generated Files
+
+### `master.cshtml`
+
+```razor
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <title>Acme</title>
+</head>
+<body>
+    @await Html.PartialAsync("~/Views/Partials/navigation.cshtml")
+
+    @RenderBody()
+
+    @await Html.PartialAsync("~/Views/Partials/footer.cshtml")
+</body>
+</html>
+```
+
+---
+
+### `homePage.cshtml`
+
+```razor
+@using Umbraco.Cms.Web.Common.PublishedModels;
+@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<ContentModels.HomePage>
+    @using ContentModels = Umbraco.Cms.Web.Common.PublishedModels;
+@{
+    Layout = "master.cshtml";
+}
+
+<main>
+    @Html.GetBlockListHtml(Model.MainContent)
+</main>
+```
+
+---
+
+### `Views/Partials/navigation.cshtml`
+
+```razor
+@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage
+
+<nav class="main-nav">
+    <a href="/">Home</a>
+    <a href="/about">About</a>
+</nav>
+```
+
+---
+
+### `Views/Partials/blocklist/default.cshtml`
+
+```razor
+@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<Umbraco.Cms.Core.Models.Blocks.BlockListModel>
+@{
+    if (Model?.Any() != true) { return; }
+}
+<div class="umb-block-list">
+    @foreach (var block in Model)
+    {
+        if (block?.ContentUdi == null) { continue; }
+        var data = block.Content;
+
+        @await Html.PartialAsync("blocklist/Components/" + data.ContentType.Alias, block)
+    }
+</div>
+```
+
+---
+
+### `Views/Partials/blocklist/Components/heroRow.cshtml`
+
+```razor
+@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<Umbraco.Cms.Core.Models.Blocks.BlockListItem>
+
+@{
+    var row      = (HeroRow)Model.Content;
+    var settings = (HeroSettings)Model.Settings;
+
+    if (settings.Hide) { return; }
+}
+
+<section class="hero">
+    <h1>@row.Title</h1>
+    @Html.Raw(row.BodyText)
+    <img src="@Url.GetCropUrl(row.Image, 1920, 600)" alt="@row.Image?.Name" />
+    @if (row.Link != null)
+    {
+        <a href="@row.Link.Url" target="@row.Link.Target">@row.Link.Name</a>
+    }
+</section>
+```
+
+---
+
+### `Views/Partials/blocklist/Components/servicesRow.cshtml`
+
+```razor
+@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<Umbraco.Cms.Core.Models.Blocks.BlockListItem>
+
+@{
+    var row = (ServicesRow)Model.Content;
+}
+
+<section class="services">
+    <h2>@row.Title</h2>
+    <div class="service-grid">
+        @Html.GetBlockListHtml(row.ServiceGrid)
+    </div>
+</section>
+```
+
+---
+
+### `Views/Partials/blocklist/Components/serviceCardItem.cshtml`
+
+```razor
+@inherits Umbraco.Cms.Web.Common.Views.UmbracoViewPage<Umbraco.Cms.Core.Models.Blocks.BlockListItem>
+
+@{
+    var item = (ServiceCardItem)Model.Content;
+}
+
+<div class="service-card">
+    <img src="@Url.GetCropUrl(item.Icon, 80, 80)" alt="@item.Icon?.Name" />
+    <h4>@item.Title</h4>
+    @Html.Raw(item.Description)
+</div>
+```
+
+---
+
+## Final Summary Table
+
+```
+## Build Complete
+
+| Artefact | Name | Status |
+|---|---|---|
+| Element type | heroRow | ✓ Created |
+| Element type | heroSettings | ✓ Created |
+| Element type | servicesRow | ✓ Created |
+| Element type | serviceCardItem | ✓ Created |
+| Block list data type | Service Grid | ✓ Created |
+| Block list data type | Main Content | ✓ Created |
+| Page document type | homePage | ✓ Created |
+| Template | master.cshtml | ✓ Created |
+| Template | homePage.cshtml | ✓ Created |
+| Structural partial | navigation.cshtml | ✓ Created |
+| Structural partial | footer.cshtml | ✓ Created |
+| Block list dispatcher | blocklist/default.cshtml | ✓ Created |
+| Component partial | blocklist/Components/heroRow.cshtml | ✓ Created |
+| Component partial | blocklist/Components/servicesRow.cshtml | ✓ Created |
+| Component partial | blocklist/Components/serviceCardItem.cshtml | ✓ Created |
+```

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "umbraco-mcp": {
+      "command": "npx",
+      "args": ["@umbraco-cms/mcp-dev@17"],
+      "env": {
+        "UMBRACO_CLIENT_ID": "${UMBRACO_CLIENT_ID}",
+        "UMBRACO_CLIENT_SECRET": "${UMBRACO_CLIENT_SECRET}",
+        "UMBRACO_BASE_URL": "${UMBRACO_BASE_URL}",
+        "UMBRACO_INCLUDE_TOOL_COLLECTIONS": "document-type,data-type,template,partial-view,document"
+      }
+    }
+  }
+}

--- a/docs/claude-skill.md
+++ b/docs/claude-skill.md
@@ -1,0 +1,304 @@
+# Umbraco Block Builder — Claude Skill
+
+The Claude skill replaces the QuickBlocks C# package for Umbraco 17+ projects. Instead of
+annotating HTML with `data-*` attributes and running a back-office dashboard, you hand Claude
+a plain HTML prototype (or describe what you need in plain English) and it scaffolds the
+entire block list architecture for you via the Umbraco Developer MCP Server.
+
+---
+
+## Prerequisites
+
+| Requirement | Details |
+|---|---|
+| **Umbraco** | 17+ with the Management API enabled (built-in from Umbraco 14+) |
+| **Node.js** | v18+ (for `npx`) |
+| **Claude Code** | Any version, or Claude.ai with skill upload support |
+| **Umbraco API User** | An API User with admin permissions — created in the Umbraco back-office |
+
+---
+
+## 1. Create an Umbraco API User
+
+The MCP server authenticates against Umbraco using OAuth2 client credentials.
+
+1. Log in to the Umbraco back-office
+2. Go to **Settings → API Users → Create**
+3. Set permissions to **Administrator** (required for creating document types and data types)
+4. Copy the **Client ID** and **Client Secret** — you'll need these in the next step
+5. Use this against a **development or staging instance only**, not production
+
+---
+
+## 2. Configure Environment Variables
+
+Add these to your shell profile (`.zshrc`, `.bashrc`) or a `.env` file in your project root.
+Never commit secrets to source control.
+
+```bash
+export UMBRACO_CLIENT_ID="your-client-id-here"
+export UMBRACO_CLIENT_SECRET="your-client-secret-here"
+export UMBRACO_BASE_URL="https://localhost:44367"
+```
+
+The `.mcp.json` file at the root of this repo reads these variables automatically:
+
+```json
+{
+  "mcpServers": {
+    "umbraco-mcp": {
+      "command": "npx",
+      "args": ["@umbraco-cms/mcp-dev@17"],
+      "env": {
+        "UMBRACO_CLIENT_ID": "${UMBRACO_CLIENT_ID}",
+        "UMBRACO_CLIENT_SECRET": "${UMBRACO_CLIENT_SECRET}",
+        "UMBRACO_BASE_URL": "${UMBRACO_BASE_URL}",
+        "UMBRACO_INCLUDE_TOOL_COLLECTIONS": "document-type,data-type,template,partial-view,document"
+      }
+    }
+  }
+}
+```
+
+---
+
+## 3. Add the Skill to Claude
+
+### Option A — Claude Code (recommended)
+
+The skill is already in this repository at `.claude/skills/umbraco-block-builder/`. When
+you open this project in Claude Code, the skill is available automatically. No extra steps.
+
+Verify it's loaded by asking Claude:
+
+```
+When would you use the umbraco-block-builder skill?
+```
+
+Claude should describe the scaffold workflow. If it doesn't, check that the
+`.claude/skills/umbraco-block-builder/SKILL.md` file exists.
+
+### Option B — Claude.ai
+
+1. Zip the skill folder:
+   ```bash
+   cd .claude/skills
+   zip -r umbraco-block-builder.zip umbraco-block-builder/
+   ```
+2. In Claude.ai, go to **Settings → Capabilities → Skills**
+3. Upload `umbraco-block-builder.zip`
+4. Confirm the skill appears in your skills list
+
+> Note: Claude.ai does not have access to your local MCP server. Use Claude Code for the
+> full workflow including MCP tool calls. Claude.ai is useful for planning and reviewing
+> proposed structures without executing them.
+
+---
+
+## 4. Verify the MCP Connection
+
+In Claude Code, with your Umbraco instance running, ask:
+
+```
+Using the umbraco-mcp MCP server, call get-server-information and tell me the Umbraco version.
+```
+
+If it returns a version number, the connection is working. If it fails, check:
+
+- Your Umbraco instance is running and reachable at `UMBRACO_BASE_URL`
+- The API User credentials are correct
+- `npx` is available in your terminal (`npx --version`)
+
+---
+
+## 5. Using the Skill
+
+### Invoking the skill
+
+You can trigger the skill in any of these ways:
+
+```
+/umbraco-block-builder
+```
+
+Or just describe what you want — Claude will load the skill automatically:
+
+```
+Scaffold this HTML prototype as an Umbraco block list page
+```
+
+```
+Set up Umbraco blocks for a hero, services grid, and testimonials section
+```
+
+```
+Create content types from this HTML
+```
+
+### Providing input
+
+The skill accepts any of these — no `data-*` annotation required:
+
+**Plain HTML:**
+```
+Here's my prototype HTML, please scaffold it as Umbraco blocks:
+
+<section class="hero">
+  <h1>Welcome</h1>
+  <p>Intro text here.</p>
+  <img src="hero.jpg" alt="">
+  <a href="/about">Learn More</a>
+</section>
+
+<section class="features">
+  <div class="feature-card">
+    <img src="icon.svg" alt="">
+    <h3>Feature Title</h3>
+    <p>Feature description.</p>
+  </div>
+</section>
+```
+
+**Natural language:**
+```
+I need a home page with a full-width hero (heading, body text, background image, CTA link),
+a 3-column services grid where each card has an icon, title, and description,
+and a testimonials carousel with quote text, author name, and author photo.
+```
+
+**Mixed:**
+```
+Here's the hero HTML — [paste HTML]. The rest of the page needs a services section
+with three cards, each with an image and a Rich Text body.
+```
+
+### The workflow
+
+The skill follows a confirm-before-write pattern:
+
+1. **You provide input** — HTML, description, or both
+2. **Claude proposes a structure** — a list of block types, properties, and data types
+3. **You review and confirm** — reply `YES` or ask for changes
+4. **Claude creates everything** — all MCP calls happen in the correct dependency order
+5. **Claude reports** — a summary table showing what was created and its status
+
+**Example exchange:**
+
+```
+You: /umbraco-block-builder — [paste HTML]
+
+Claude:
+## Proposed Block Architecture
+
+**Page type:** Home Page (alias: homePage)
+
+**Block list:** Main Content
+  ├── Hero (element: heroRow)
+  │     title: Textstring
+  │     bodyText: Rich Text Editor
+  │     image: Image Media Picker
+  │     link: Single URL Picker
+  │   settings: heroSettings (hide: True/False)
+  │
+  └── Features (element: featuresRow)
+        [nested list] Feature Items
+            Feature Card (element: featureCardItem)
+                icon: Image Media Picker
+                title: Textstring
+                description: Rich Text Editor
+      settings: none
+
+Does this look right? Reply YES to proceed, or tell me what to change.
+
+You: YES
+
+Claude: [creates 15–20 artefacts in sequence, reports summary table]
+```
+
+### Iterating
+
+The workflow is conversational. After the initial scaffold you can continue:
+
+```
+Add a "Background Colour" dropdown to the Hero settings
+```
+
+```
+Rename "Features" to "Services" throughout
+```
+
+```
+The hero doesn't need a link — remove it
+```
+
+---
+
+## 6. What Gets Created
+
+For a typical page with 2–3 block types, the skill creates:
+
+| Artefact | Location in Umbraco |
+|---|---|
+| Document type folder | Settings → Document Types → Elements |
+| Element type per block | Settings → Document Types → Elements/Content Models |
+| Settings type per block | Settings → Document Types → Elements/Settings Models |
+| Page document type | Settings → Document Types → Pages |
+| Block list data type | Settings → Data Types |
+| Master template | Settings → Templates → Master |
+| Content page template | Settings → Templates → {Page Name} |
+| Navigation partial | Views/Partials/navigation.cshtml |
+| Footer partial | Views/Partials/footer.cshtml |
+| Block list dispatcher | Views/Partials/blocklist/default.cshtml |
+| Component partial per block | Views/Partials/blocklist/Components/{alias}.cshtml |
+
+---
+
+## 7. Troubleshooting
+
+**Skill doesn't trigger automatically**
+
+Ask Claude directly: `/umbraco-block-builder` — this forces it to load. If the skill body
+never appears in the response, check that `SKILL.md` exists at
+`.claude/skills/umbraco-block-builder/SKILL.md`.
+
+**MCP connection fails**
+
+```
+Error: connect ECONNREFUSED
+```
+
+- Check `UMBRACO_BASE_URL` — include the port, e.g. `https://localhost:44367`
+- Check that Umbraco is running (`dotnet run` or IIS/Kestrel)
+- Check that the API User credentials match what's in the back-office
+
+**Partial view subfolder returns 404**
+
+This is a known Umbraco bug ([#16823](https://github.com/umbraco/Umbraco-CMS/issues/16823))
+affecting paths deeper than one level (e.g. `blocklist/Components/hero.cshtml`). The skill
+will note the workaround in its summary and place the file at root level if needed.
+
+**Duplicate artefact error**
+
+If you run the skill twice on the same project, it will detect existing artefacts via
+`get-all-document-types` / `get-all-data-types` and reuse their GUIDs instead of creating
+duplicates.
+
+**Wrong Umbraco version**
+
+The block list configuration JSON changed between Umbraco 10 and 17. The skill targets v17.
+If `get-server-information` returns a version below 17, the skill will warn you before
+proceeding.
+
+---
+
+## Comparison with the QuickBlocks C# Package
+
+| | QuickBlocks (C# package) | Claude Skill |
+|---|---|---|
+| **Umbraco version** | 10 | 17+ |
+| **Input** | Annotated HTML (`data-*` attributes) | Plain HTML, natural language, screenshot |
+| **Annotation required** | Yes — developer must name every property | No — Claude infers from HTML semantics |
+| **Iteration** | Re-annotate and re-run | Conversational — describe changes in plain English |
+| **Maintenance** | NuGet release per Umbraco major version | Edit one Markdown file |
+| **Dependencies** | `Umbraco.Cms.Core`, `HtmlAgilityPack` | `npx` (no install), one JSON config |
+| **Error recovery** | Partial creation, hard to debug | Claude explains failures and offers alternatives |


### PR DESCRIPTION
Implements the Claude skill proposed in CLAUDE_SKILL_PROPOSAL.md, replacing
the C# QuickBlocks package with a SKILL.md-driven workflow that scaffolds
a complete Umbraco 17 block list architecture via the Umbraco Developer MCP
Server — no NuGet package, no data-* annotation required.

Files added:
- .claude/skills/umbraco-block-builder/SKILL.md  — full skill definition
- .mcp.json                                       — MCP server configuration

https://claude.ai/code/session_01Rh5kCnb3MskuDUmToWbCbe